### PR TITLE
Guarantee the array order

### DIFF
--- a/map2json.c
+++ b/map2json.c
@@ -173,15 +173,15 @@ map2json_tree_t *map2json_getArrayObject(map2json_tree_t *obj, long arrayId) {
 		if ( arrObj->arrayId == arrayId ) {
 			return arrObj;
 		}
-		arrObj = arrObj->next;
+		arrObj = arrObj->arrayObjects;
 
 	}
 	arrObj = map2json_createEmptyTreeObject(NULL);
 	if ( obj->maxArrayId < arrayId ) {
-		obj->maxArrayId = arrayId;
+		obj->maxArrayId = arrayId + 1;
 	}
 	arrObj->arrayId = arrayId;
-	arrObj->next = obj->arrayObjects;
+	arrObj->arrayObjects = obj->arrayObjects;
 	obj->arrayObjects = arrObj;
 
 	return arrObj;
@@ -248,13 +248,16 @@ void map2json_createJsonStringArray(csafestring_t *buffer, map2json_tree_t *tree
 	int i;
 	safe_strchrappend(buffer, JSON2MAP_MAP_ARRAY_START);
 
-	for ( i = 0; i < tree->maxArrayId + 1; i++ ) {
+	for ( i = 0; i < tree->maxArrayId; i++ ) {
 		map2json_tree_t *arrayObj = tree->arrayObjects;
 		while ( arrayObj != NULL ) {
 			if ( arrayObj->arrayId == i ) {
 				map2json_createJsonString(buffer, arrayObj);
 			}
 			arrayObj = arrayObj->arrayObjects;
+		}
+		if ( i < tree->maxArrayId - 1 ) {
+			safe_strchrappend(buffer, ',');
 		}
 	}
 	safe_strchrappend(buffer, JSON2MAP_MAP_ARRAY_END);

--- a/test/testcases.c
+++ b/test/testcases.c
@@ -93,17 +93,18 @@ int test_map2json_numberFloat() {
 }
 
 int test_map2json_array() {
-//	map2json_t *map2jsonObj = map2json_init();
-//	map2json_push(map2jsonObj, "array[0].object1.key1", "value1");
-//	map2json_push(map2jsonObj, "array[0].object1.key2", "2");
-//	map2json_push(map2jsonObj, "array[3]", "1");
-//	map2json_push(map2jsonObj, "array[2]", "b");
-//	map2json_push(map2jsonObj, "array[1].array2[0]", "test");
-//	map2json_push(map2jsonObj, "array[1].array2[1]", "test2");
-//	map2json_push(map2jsonObj, "array[x]", "4");
-//
-//	ASSERTSTR("{\"array\":[{\"object1\":{\"key1\":\"value1\",\"key2\":2}},{\"array2\":[\"test\",\"test2\"]},\"b\",1]}", map2json_create(map2jsonObj));
-//	map2json_destroy(map2jsonObj);
+	map2json_t *map2jsonObj = map2json_init();
+	map2json_push(map2jsonObj, "array[0].object1.key1", "value1");
+	map2json_push(map2jsonObj, "array[0].object1.key2", "2");
+	map2json_push(map2jsonObj, "array[3]", "1");
+	map2json_push(map2jsonObj, "array[2]", "b");
+	map2json_push(map2jsonObj, "array[1].array2[0]", "test");
+	map2json_push(map2jsonObj, "array[1].array2[1]", "test2");
+	map2json_push(map2jsonObj, "array[1].array2[x]", "2");
+	map2json_push(map2jsonObj, "array[x]", "4");
+
+	ASSERTSTR("{\"array\":[{\"object1\":{\"key1\":\"value1\",\"key2\":2}},{\"array2\":[\"test\",\"test2\"]},\"b\",1]}", map2json_create(map2jsonObj));
+	map2json_destroy(map2jsonObj);
 	return 0;
 }
 


### PR DESCRIPTION
* FIX: if an array was not in order pushed to map2json, the right order was not guaranteed.